### PR TITLE
Allow using double quotes within triple double quotes.

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -149,6 +149,9 @@ def _get_word(self) -> str:
                 log.trace(f"{arg} is not a str, casting to str.")
                 arg = str(arg)
 
+            # Allow using double quotes within triple double quotes
+            arg = arg.replace('"', '\\"')
+
             # Adding double quotes to every argument
             log.trace(f"Wrapping all args in double quotes.")
             new_args.append(f'"{arg}"')


### PR DESCRIPTION
`1nbze` on clickup: "modify the python syntax parser so that it will automatically escape any double quotes within a triple double quote block. currently it is necessary to manually escape these."

When using double quotes within a triple quote block, the Python syntax parser would previously error. This fixes that by escaping any double quotes:

![img1](https://cdn.discordapp.com/attachments/417755308891439124/433943423515492367/unknown.png)
![img2](https://cdn.discordapp.com/attachments/417755308891439124/433943935958646784/unknown.png)
