### PR TITLE
Allow `__getitem__` / `__setitem__`-like command access

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -177,8 +177,7 @@ def _get_word(self) -> str:
         def clean_argument(arg: str) -> str:
             """Helper function to remove any characters we don't care about."""
 
-            return arg.strip("[]'\" ") \
-                    .replace('"', '\\"')
+            return arg.strip("[]'\" ").replace('"', '\\"')
 
         log.trace(f"Got a command candidate for getitem / setitem mimick: {self.buffer}")
         # Syntax is `bot.tags['ask']` => mimic `getattr`

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -181,6 +181,8 @@ def _get_word(self) -> str:
         # Syntax is `bot.tags['ask']` => mimic `getattr`
         if self.buffer.endswith("]"):
             key = clean_argument(self.buffer[self.index:])
+            # note: if not key, this corresponds to an empty argument
+            #       so this should throw / return a SyntaxError ?
             arg = f"\"{key}\""
             result = self.buffer[self.previous:self.index] + ".get"
 
@@ -193,6 +195,7 @@ def _get_word(self) -> str:
             arg = f"\"{key}\" \"{value}\""
 
         # Syntax is god knows what, pass it along
+        # in the future, this should probably return / throw SyntaxError
         else:
             result = self.buffer
             arg = ''
@@ -200,7 +203,6 @@ def _get_word(self) -> str:
         self.buffer = f"{result} {arg}"
         self.index = len(result)
         self.end = len(self.buffer)
-
 
     if isinstance(result, str):
         return result.lower()  # Case insensitivity, baby

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -177,7 +177,8 @@ def _get_word(self) -> str:
         def clean_argument(arg: str) -> str:
             """Helper function to remove any characters we don't care about."""
 
-            return arg.strip("[]'\" ")
+            return arg.strip("[]'\" ") \
+                    .replace('"', '\\"')
 
         log.trace(f"Got a command candidate for getitem / setitem mimick: {self.buffer}")
         # Syntax is `bot.tags['ask']` => mimic `getattr`
@@ -205,8 +206,7 @@ def _get_word(self) -> str:
                 clean_argument(
                     self.buffer.split("=")[1]
                 )
-                .replace('"', '\\"')  # escape any unescaped quotes
-                .replace("'", "\\'")  # to mimic triple quote behaviour.
+                .replace("'", "\\'")  # escape any unescaped quotes
             )
             log.trace(f"Command mimicks setitem. Key: {key!r}, value: {value!r}.")
 

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -179,10 +179,12 @@ def _get_word(self) -> str:
 
             return arg.strip("[]'\" ")
 
+        log.trace(f"Got a command candidate for getitem / setitem mimick: {self.buffer}")
         # Syntax is `bot.tags['ask']` => mimic `getattr`
         if self.buffer.endswith("]"):
             # Key: The first argument, specified `bot.tags[here]`
             key = clean_argument(self.buffer[self.index:])
+            log.trace(f"Command mimicks getitem. Key: {key!r}")
 
             # note: if not key, this corresponds to an empty argument
             #       so this should throw / return a SyntaxError ?
@@ -206,6 +208,7 @@ def _get_word(self) -> str:
                 .replace('"', '\\"')  # escape any unescaped quotes
                 .replace("'", "\\'")  # to mimic triple quote behaviour.
             )
+            log.trace(f"Command mimicks setitem. Key: {key!r}, value: {value!r}.")
 
             # Use the cog's `set` command.
             result = self.buffer[self.previous:self.index] + ".set"
@@ -216,11 +219,13 @@ def _get_word(self) -> str:
         else:
             result = self.buffer
             args = ''
+            log.trace(f"Command is of unknown syntax: {self.buffer}")
 
         # Reconstruct valid discord.py syntax
         self.buffer = f"{result} {args}"
         self.index = len(result)
         self.end = len(self.buffer)
+        log.trace(f"Mimicked command: {self.buffer}")
 
     if isinstance(result, str):
         return result.lower()  # Case insensitivity, baby

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -183,17 +183,21 @@ def _get_word(self) -> str:
         if self.buffer.endswith("]"):
             # Key: The first argument, specified `bot.tags[here]`
             key = clean_argument(self.buffer[self.index:])
+
             # note: if not key, this corresponds to an empty argument
             #       so this should throw / return a SyntaxError ?
-            args = f"\"{key}\""
+            args = f'"{key}"'
+
             # Use the cog's `get` command.
             result = self.buffer[self.previous:self.index] + ".get"
 
         # Syntax is `bot.tags['ask'] = 'whatever'` => mimic `setattr`
         elif "=" in self.buffer and not self.buffer.endswith("="):
             equals_pos = self.buffer.find("=")
+
             # Key: The first argument, specified `bot.tags[here]`
             key = clean_argument(self.buffer[self.index:equals_pos])
+
             # Value: The second argument, specified after the `=`
             value = (
                 clean_argument(
@@ -202,6 +206,7 @@ def _get_word(self) -> str:
                 .replace('"', '\\"')  # escape any unescaped quotes
                 .replace("'", "\\'")  # to mimic triple quote behaviour.
             )
+
             # Use the cog's `set` command.
             result = self.buffer[self.previous:self.index] + ".set"
             args = f'"{key}" "{value}"'

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -149,6 +149,9 @@ def _get_word(self) -> str:
                 log.trace(f"{arg} is not a str, casting to str.")
                 arg = str(arg)
 
+            # Allow using double quotes within triple double quotes
+            arg = arg.replace('"', '\\"')
+
             # Adding double quotes to every argument
             log.trace(f"Wrapping all args in double quotes.")
             new_args.append(f'"{arg}"')

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -171,7 +171,8 @@ def _get_word(self) -> str:
         result = self.buffer[self.previous:self.index + (pos+2)]
         self.index += 2
 
-    # Check if a command in the form of `bot.tags['ask'] {= 'whatever'}` was used
+    # Check if a command in the form of `bot.tags['ask']`
+    # or alternatively `bot.tags['ask'] = 'whatever'` was used.
     elif current == "[":
         def clean_argument(arg: str) -> str:
             """Helper function to remove any characters we don't care about."""
@@ -203,7 +204,7 @@ def _get_word(self) -> str:
             )
             # Use the cog's `set` command.
             result = self.buffer[self.previous:self.index] + ".set"
-            args = f"\"{key}\" \"{value}\""
+            args = f'"{key}" "{value}"'
 
         # Syntax is god knows what, pass it along
         # in the future, this should probably return / throw SyntaxError

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -173,8 +173,9 @@ def _get_word(self) -> str:
 
     # Check if a command in the form of `bot.tags['ask'] {= 'whatever'}` was used
     elif current == "[":
-        # Helper function to remove any characters we don't care about
         def clean_argument(arg: str) -> str:
+            """Helper function to remove any characters we don't care about."""
+
             return arg.strip("[]'\" ")
 
         # Syntax is `bot.tags['ask']` => mimic `getattr`
@@ -193,9 +194,13 @@ def _get_word(self) -> str:
             # Key: The first argument, specified `bot.tags[here]`
             key = clean_argument(self.buffer[self.index:equals_pos])
             # Value: The second argument, specified after the `=`
-            value = (clean_argument(self.buffer.split("=")[1])
-                     .replace("\"", "\\\"")  # escape any unescaped quotes
-                     .replace("'", "\\'"))   # to mimic triple quote behaviour.
+            value = (
+                clean_argument(
+                    self.buffer.split("=")[1]
+                )
+                .replace('"', '\\"')  # escape any unescaped quotes
+                .replace("'", "\\'")  # to mimic triple quote behaviour.
+            )
             # Use the cog's `set` command.
             result = self.buffer[self.previous:self.index] + ".set"
             args = f"\"{key}\" \"{value}\""


### PR DESCRIPTION
clickup task: `1aw8t` "Allow bot.tags['zen'] in addition to bot.tags.get('zen') and bot.tags['zen'] = 'superzen' in addition to bot.tags.set('zen', 'superzen')"

This allows users to use cogs containing a `get` and `set` command as they would use a dictionary:

- `bot.tags["ask"]` delegates to `bot.tags.get("ask")`
- `bot.tags["ask"] = "don't"` delegates to `bot.tags.set("ask", "don't")`

![examples](https://cdn.discordapp.com/attachments/434048683135205387/434066774443425793/unknown.png)
![more examples](https://cdn.discordapp.com/attachments/434048683135205387/434072928393625600/unknown.png)