### PR TITLE
Allow `__delitem__`-like tag deletion.

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -201,22 +201,18 @@ def _get_word(self) -> str:
             key = clean_argument(self.buffer[self.index:equals_pos])
 
             # Value: The second argument, specified after the `=`
-            rhs = self.buffer.split("=")[1].strip()
+            right_hand = self.buffer.split("=", maxsplit=1)[1].strip()
 
             # If the value is None or '', mimick `bot.tags.delete(key)`
-            if rhs in ("None", "''", '""'):
+            if right_hand in ("None", "''", '""'):
                 log.trace(f"Command mimicks delitem. Key: {key!r}.")
                 result = self.buffer[self.previous:self.index] + ".delete"
                 args = f'"{key}"'
 
             # Otherwise, assume assignment, for example `bot.tags['this'] = 'that'`
             else:
-                value = (
-                    clean_argument(
-                        rhs
-                    )
-                    .replace("'", "\\'")  # escape any unescaped quotes
-                )
+                # Escape any unescaped quotes
+                value = clean_argument(right_hand).replace("'", "\\'")
                 log.trace(f"Command mimicks setitem. Key: {key!r}, value: {value!r}.")
 
                 # Use the cog's `set` command.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -201,17 +201,27 @@ def _get_word(self) -> str:
             key = clean_argument(self.buffer[self.index:equals_pos])
 
             # Value: The second argument, specified after the `=`
-            value = (
-                clean_argument(
-                    self.buffer.split("=")[1]
-                )
-                .replace("'", "\\'")  # escape any unescaped quotes
-            )
-            log.trace(f"Command mimicks setitem. Key: {key!r}, value: {value!r}.")
+            rhs = self.buffer.split("=")[1].strip()
 
-            # Use the cog's `set` command.
-            result = self.buffer[self.previous:self.index] + ".set"
-            args = f'"{key}" "{value}"'
+            # If the value is None or '', mimick `bot.tags.delete(key)`
+            if rhs in ("None", "''", '""'):
+                log.trace(f"Command mimicks delitem. Key: {key!r}.")
+                result = self.buffer[self.previous:self.index] + ".delete"
+                args = f'"{key}"'
+
+            # Otherwise, assume assignment, for example `bot.tags['this'] = 'that'`
+            else:
+                value = (
+                    clean_argument(
+                        rhs
+                    )
+                    .replace("'", "\\'")  # escape any unescaped quotes
+                )
+                log.trace(f"Command mimicks setitem. Key: {key!r}, value: {value!r}.")
+
+                # Use the cog's `set` command.
+                result = self.buffer[self.previous:self.index] + ".set"
+                args = f'"{key}" "{value}"'
 
         # Syntax is god knows what, pass it along
         # in the future, this should probably return / throw SyntaxError

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -349,6 +349,16 @@ class Tags:
 
         return await ctx.send(embed=embed)
 
+    @command(name="tags.keys()")
+    async def keys_command(self, ctx: Context):
+        """
+        Alias for `tags.get()` with no arguments.
+
+        :param ctx: discord message context
+        """
+
+        return await ctx.invoke(self.get_command)
+
 
 def setup(bot):
     bot.add_cog(Tags(bot))


### PR DESCRIPTION
clickup `21v8y`: "Allow tags to be removed with bot.tags["item"] = None. Also add keys as an alias to get, so that bot.tags.keys() will return the tag names. Now that it acts like a dict, we might as well support one more dict method."


Allows users to delete tags using the `__setitem__` syntax, when using `None` or empty strings (`''`, `""`) as the value. Additionally, add `tags.keys()` as an alias for `tags.get()` (doesn't take any arguments).