### PR TITLE
[ClickUp #21zkw] Commands cleanup

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -10,13 +10,15 @@ from bot.utils import CaseInsensitiveDict
 
 bot = AutoShardedBot(
     command_prefix=when_mentioned_or(
-        ">>> self.", ">> self.", "> self.", "self.",
-        ">>> bot.", ">> bot.", "> bot.", "bot.",
-        ">>> ", ">> ", "> ",
-        ">>>", ">>", ">"
-    ),  # Order matters (and so do commas)
-    activity=Game(name="Help: bot.help()"),
-    help_attrs={"aliases": ["help()"]},
+        "self.", "bot."
+    ),
+    activity=Game(
+        name="Help: bot.help()"
+    ),
+    help_attrs={
+        "name": "help()",
+        "aliases": ["help"]
+    },
     formatter=Formatter()
 )
 

--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -72,7 +72,7 @@ class Bot:
         log.info(f"{ctx.author} called bot.about(). Returning information about the bot.")
         await ctx.send(embed=embed)
 
-    @command(name="info()", aliases=["bot.info", "bot.about", "bot.about()", "info", "bot.info()"])
+    @command(name="info()", aliases=["info", "about()", "about"])
     @with_role(VERIFIED_ROLE)
     async def info_wrapper(self, ctx: Context):
         """
@@ -81,7 +81,7 @@ class Bot:
 
         await ctx.invoke(self.info)
 
-    @command(name="echo")
+    @command(name="print()", aliases=["print", "echo", "echo()"])
     @with_role(OWNER_ROLE, ADMIN_ROLE, MODERATOR_ROLE)
     async def echo_command(self, ctx: Context, text: str):
         """
@@ -90,7 +90,7 @@ class Bot:
 
         await ctx.send(text)
 
-    @command(name="embed")
+    @command(name="embed()", aliases=["embed"])
     @with_role(OWNER_ROLE, ADMIN_ROLE, MODERATOR_ROLE)
     async def embed_command(self, ctx: Context, text: str):
         """

--- a/bot/cogs/eval.py
+++ b/bot/cogs/eval.py
@@ -19,11 +19,10 @@ from bot.interpreter import Interpreter
 log = logging.getLogger(__name__)
 
 
-class EvalCog:  # Named this way because a flake8 plugin isn't case-sensitive
+class CodeEval:
     """
-    Bot owner only: Evaluate Python code
-
-    Made by martmists
+    Owner and admin feature that evaluates code
+    and returns the result to the channel.
     """
 
     def __init__(self, bot: AutoShardedBot):
@@ -166,17 +165,17 @@ async def func():  # (None,) -> Any
 """.format(textwrap.indent(code, '            '))
 
         try:
-            exec(_code, self.env)  # noqa: B102 S102 pylint: disable=exec-used
+            exec(_code, self.env)  # noqa: B102,S102
             func = self.env['func']
             res = await func()
 
-        except Exception:  # noqa pylint: disable=broad-except
+        except Exception:
             res = traceback.format_exc()
 
         out, embed = self._format(code, res)
         await ctx.send(f"```py\n{out}```", embed=embed)
 
-    @command()
+    @command(name="eval()", aliases=["eval"])
     @with_role(ADMIN_ROLE, OWNER_ROLE)
     async def eval(self, ctx, *, code: str):
         """ Run eval in a REPL-like format. """
@@ -194,5 +193,5 @@ async def func():  # (None,) -> Any
 
 
 def setup(bot):
-    bot.add_cog(EvalCog(bot))
+    bot.add_cog(CodeEval(bot))
     log.info("Cog loaded: Eval")

--- a/bot/cogs/math.py
+++ b/bot/cogs/math.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import suppress
 from io import BytesIO
 from re import search
-from subprocess import PIPE, Popen, STDOUT, TimeoutExpired  # noqa: B404 S404
+from subprocess import PIPE, Popen, STDOUT, TimeoutExpired  # noqa: B404,S404
 
 from discord import File
 from discord.ext.commands import command
@@ -24,7 +24,7 @@ async def run_sympy(sympy_code: str, calc: bool = False, timeout: int = 10) -> s
         # They're trying to exploit something, raise an error
         raise TypeError("'__' not allowed in sympy code")
 
-    proc = Popen([  # noqa: B603 S603
+    proc = Popen([  # noqa: B603,S603
                     sys.executable, "-c",
                     "import sys,sympy;from sympy.parsing.sympy_parser import parse_expr;"
                     f"print(sympy.latex({code_}))", sympy_code

--- a/bot/formatter.py
+++ b/bot/formatter.py
@@ -119,7 +119,7 @@ class Formatter(HelpFormatter):
         def category_check(tup):
             cog = tup[1].cog_name
             # zero width character to make it appear last when put in alphabetical order
-            return cog if cog is not None else "\u200bNoCategory"
+            return cog if cog is not None else "Bot"
 
         command_list = await self.filter_command_list()
         data = sorted(command_list, key=category_check)


### PR DESCRIPTION
Python-syntax calls are now the default for all commands, but bracketless calls are still available as aliases. This makes the help output completely uniform.

I also removed NoCategory and just added those commands to the Bot category to reduce clutter, and made bot.print the default and bot.echo an alias. 

Also renamed the EvalCog to CodeEval to be more uniform. new bot.help output attached to this PR. Some of the noqa's in the math and eval files had to be changed to pass flake8.

New output looks like this:

![image](https://user-images.githubusercontent.com/2098517/38861934-fe8c3fee-4233-11e8-9bb8-b5dae9b7f079.png)
