### PR TITLE
Use discord.py's case insensitivity instead of patching `bot.cogs` ourselves

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -232,8 +232,6 @@ def _get_word(self) -> str:
         self.end = len(self.buffer)
         log.trace(f"Mimicked command: {self.buffer}")
 
-    if isinstance(result, str):
-        return result.lower()  # Case insensitivity, baby
     return result
 
 

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -6,7 +6,6 @@ from discord import Game
 from discord.ext.commands import AutoShardedBot, when_mentioned_or
 
 from bot.formatter import Formatter
-from bot.utils import CaseInsensitiveDict
 
 bot = AutoShardedBot(
     command_prefix=when_mentioned_or(
@@ -19,11 +18,9 @@ bot = AutoShardedBot(
         "name": "help()",
         "aliases": ["help"]
     },
-    formatter=Formatter()
+    formatter=Formatter(),
+    case_insensitive=True
 )
-
-# Make cog names case-insensitive
-bot.cogs = CaseInsensitiveDict()
 
 # Global aiohttp session for all cogs - uses asyncio for DNS resolution instead of threads, so we don't *spam threads*
 bot.http_session = ClientSession(connector=TCPConnector(resolver=AsyncResolver()))


### PR DESCRIPTION
ClickUp `21rc8`:
> Use d.py's built-in case insensitivity instead of our own.

> Discord rewrite now supports case insensitivity by simply passing case_insensitive=True into the bot constructor. This means we should probably replace our current case insensitivity monkey patching with this system instead, and we might not even need our case insensitive dict anymore. 
However, we need to test this properly before we replace. Does it work for prefixes and commands? Are we losing anything by using this method instead of todays method?

Instead of patching `bot.cogs`, this just passes `case_insensitive=True` to discord.py's bot constructor.

`CaseInsensitiveDict` is still used in the ClickUp cog:
https://github.com/discord-python/bot/blob/master/bot/cogs/clickup.py#L32-L39