### PR TITLE
Declaring the encoding to be utf-8 is not necessary in Python3.

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import ast
 import logging
 import re

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import os
 
 from aiohttp import AsyncResolver, ClientSession, TCPConnector

--- a/bot/cogs/__init__.py
+++ b/bot/cogs/__init__.py
@@ -1,1 +1,0 @@
-# coding=utf-8

--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import ast
 import logging
 import re

--- a/bot/cogs/clickup.py
+++ b/bot/cogs/clickup.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord import Colour, Embed

--- a/bot/cogs/cogs.py
+++ b/bot/cogs/cogs.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 import os
 

--- a/bot/cogs/deployment.py
+++ b/bot/cogs/deployment.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord import Colour, Embed

--- a/bot/cogs/eval.py
+++ b/bot/cogs/eval.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import contextlib
 import inspect
 import logging

--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord import Embed, Member

--- a/bot/cogs/fun.py
+++ b/bot/cogs/fun.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord import Message

--- a/bot/cogs/hiphopify.py
+++ b/bot/cogs/hiphopify.py
@@ -28,7 +28,7 @@ class Hiphopify:
         """
         This event will trigger when someone changes their name.
         At this point we will look up the user in our database and check
-        whether they are allowed o change their names, or if they are in
+        whether they are allowed to change their names, or if they are in
         hiphop-prison. If they are not allowed, we will change it back.
         :return:
         """

--- a/bot/cogs/logging.py
+++ b/bot/cogs/logging.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord import Embed

--- a/bot/cogs/security.py
+++ b/bot/cogs/security.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord.ext.commands import AutoShardedBot, Context

--- a/bot/cogs/verification.py
+++ b/bot/cogs/verification.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord import Message, Object

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import os
 
 # Server

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import logging
 
 from discord.ext import commands

--- a/bot/formatter.py
+++ b/bot/formatter.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 """
 Credit to Rapptz's script used as an example:
 https://github.com/Rapptz/discord.py/blob/rewrite/discord/ext/commands/formatter.py

--- a/bot/interpreter.py
+++ b/bot/interpreter.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from code import InteractiveInterpreter
 from io import StringIO
 

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 import asyncio
 import logging
 from typing import Iterable, Optional

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,5 +1,3 @@
-
-
 class CaseInsensitiveDict(dict):
     """
     We found this class on StackOverflow. Thanks to m000 for writing it!

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 
 
 class CaseInsensitiveDict(dict):


### PR DESCRIPTION
UTF-8 is the default encoding in Python3 - see [PEP3120](https://www.python.org/dev/peps/pep-3120/). Encoding declarations are only useful in py3 if you want to declare it to be something _other_ than utf-8.

This is basically a Python2 convention that someone has carried over. Since it doesn't actually do anything at all, it should be removed.