### PR TITLE
Fixed a critical bug with Hiphopify

### DIFF
--- a/bot/cogs/hiphopify.py
+++ b/bot/cogs/hiphopify.py
@@ -49,7 +49,7 @@ class Hiphopify:
 
         response = await response.json()
 
-        if response:
+        if response and response.get("end_timestamp") and not response.get("error_code"):
             if after.display_name == response.get("forced_nick"):
                 return  # Nick change was triggered by this event. Ignore.
 
@@ -128,9 +128,11 @@ class Hiphopify:
 
             embed.title = "Congratulations!"
             embed.description = (
-                "Your previous nickname was so bad that we have decided to change it. "
+                f"Your previous nickname, **{member.display_name}**, was so bad that we have decided to change it. "
                 f"Your new nickname will be **{forced_nick}**.\n\n"
-                f"You will be unable to change your nickname back until \n**{end_time}**."
+                f"You will be unable to change your nickname until \n**{end_time}**.\n\n"
+                "If you're confused by this, please read our "
+                "[official nickname policy](https://pythondiscord.com/about/rules#nickname-policy)."
             )
             embed.set_image(url=image_url)
 
@@ -146,7 +148,7 @@ class Hiphopify:
             # Change the nick and return the embed
             log.debug("Changing the users nickname and sending the embed.")
             await member.edit(nick=forced_nick)
-            await ctx.send(member.mention, embed=embed)
+            await ctx.send(embed=embed)
 
     @with_role(ADMIN_ROLE, OWNER_ROLE, MODERATOR_ROLE)
     @command(name="unhiphopify()", aliases=["unhiphopify", "release_nick()", "release_nick"])


### PR DESCRIPTION
The bug makes it impossible for users to change their nicknames while Bot Staging is running. After this is merged, all testing bots **must** update their branches. 

Also fixed a couple of minor aesthetic problems with the hiphopify embed. It now looks like this:

![image](https://user-images.githubusercontent.com/2098517/39366220-919a63e0-4a33-11e8-8aae-1421a9fd7a74.png)

It no longer mentions the user (cause we're doing that when we call the command), it links the nickname policy in the embed, and it says in the embed what the users old nickname was.