### PR TITLE
Use `Bot` instead of `AutoShardedBot`.

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -3,15 +3,15 @@ import socket
 
 from aiohttp import AsyncResolver, ClientSession, TCPConnector
 from discord import Game
-from discord.ext.commands import AutoShardedBot, when_mentioned_or
+from discord.ext.commands import Bot, when_mentioned_or
 
-from bot.constants import Bot, ClickUp
+from bot.constants import Bot as BotConfig, ClickUp
 from bot.formatter import Formatter
 
 
 log = logging.getLogger(__name__)
 
-bot = AutoShardedBot(
+bot = Bot(
     command_prefix=when_mentioned_or(
         "self.", "bot."
     ),
@@ -61,6 +61,6 @@ bot.load_extension("bot.cogs.snakes")
 bot.load_extension("bot.cogs.tags")
 bot.load_extension("bot.cogs.verification")
 
-bot.run(Bot.token)
+bot.run(BotConfig.token)
 
 bot.http_session.close()  # Close the aiohttp session when the bot finishes running

--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -4,7 +4,7 @@ import re
 import time
 
 from discord import Embed, Message
-from discord.ext.commands import AutoShardedBot, Context, command, group
+from discord.ext.commands import Bot, Context, command, group
 from dulwich.repo import Repo
 
 from bot.constants import (
@@ -20,7 +20,7 @@ class Bot:
     Bot information commands
     """
 
-    def __init__(self, bot: AutoShardedBot):
+    def __init__(self, bot: Bot):
         self.bot = bot
 
         # Stores allowed channels plus epoch time since last call.

--- a/bot/cogs/clickup.py
+++ b/bot/cogs/clickup.py
@@ -1,7 +1,7 @@
 import logging
 
 from discord import Colour, Embed
-from discord.ext.commands import AutoShardedBot, Context, command
+from discord.ext.commands import Bot, Context, command
 from multidict import MultiDict
 
 from bot.constants import ClickUp as ClickUpConfig, Roles
@@ -31,7 +31,7 @@ class ClickUp:
     ClickUp management commands
     """
 
-    def __init__(self, bot: AutoShardedBot):
+    def __init__(self, bot: Bot):
         self.bot = bot
         self.lists = CaseInsensitiveDict()
 

--- a/bot/cogs/eval.py
+++ b/bot/cogs/eval.py
@@ -8,7 +8,7 @@ import traceback
 from io import StringIO
 
 import discord
-from discord.ext.commands import AutoShardedBot, command
+from discord.ext.commands import Bot, command
 
 from bot.constants import Roles
 from bot.decorators import with_role
@@ -23,7 +23,7 @@ class CodeEval:
     and returns the result to the channel.
     """
 
-    def __init__(self, bot: AutoShardedBot):
+    def __init__(self, bot: Bot):
         self.bot = bot
         self.env = {}
         self.ln = 0

--- a/bot/cogs/hiphopify.py
+++ b/bot/cogs/hiphopify.py
@@ -3,7 +3,7 @@ import random
 
 from discord import Colour, Embed, Member
 from discord.errors import Forbidden
-from discord.ext.commands import AutoShardedBot, Context, command
+from discord.ext.commands import Bot, Context, command
 
 from bot.constants import (
     Channels, Keys,
@@ -21,7 +21,7 @@ class Hiphopify:
     A set of commands to moderate terrible nicknames.
     """
 
-    def __init__(self, bot: AutoShardedBot):
+    def __init__(self, bot: Bot):
         self.bot = bot
         self.headers = {"X-API-KEY": Keys.site_api}
 

--- a/bot/cogs/snakes.py
+++ b/bot/cogs/snakes.py
@@ -14,7 +14,7 @@ from typing import Any, Dict
 import aiohttp
 import async_timeout
 from discord import Colour, Embed, File, Member, Message, Reaction
-from discord.ext.commands import AutoShardedBot, BadArgument, Context, bot_has_permissions, command
+from discord.ext.commands import BadArgument, Bot, Context, bot_has_permissions, command
 from PIL import Image, ImageDraw, ImageFont
 
 from bot.constants import ERROR_REPLIES, Keys, URLs
@@ -146,7 +146,7 @@ class Snakes:
     wiki_brief = re.compile(r'(.*?)(=+ (.*?) =+)', flags=re.DOTALL)
     valid_image_extensions = ('gif', 'png', 'jpeg', 'jpg', 'webp')
 
-    def __init__(self, bot: AutoShardedBot):
+    def __init__(self, bot: Bot):
         self.active_sal = {}
         self.bot = bot
         self.headers = {"X-API-KEY": Keys.site_api}


### PR DESCRIPTION
I am glad to announce that our highly trained engineer monkeys have finally accomplished the complex task that mankind struggled on for the entirety of 4 days, and made the bot use `discord.ext.commands.Bot` instead of `discord.ext.commands.AutoShardedBot`.

(Closes #87.)